### PR TITLE
Add an auto-discovery mode to milkzmqServer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,200 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     150
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+StatementAttributeLikeMacros:
+  - Q_EMIT
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 milkzmqClient
 milkzmqServer
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 ######################################################
-## makefile for milkzmq                             ##
-##                                                  ## 
-## Edit BIN_PATH to specify installation directory. ##
+## Makefile for milkzmq.                            ##
 ######################################################
 
-#This will change for both client and server
-export BIN_PATH=/usr/local/bin
-export INC_PATH=/usr/local/include
+ifeq ($(wildcard /opt/magaox),)
+export BIN_PATH	:= /usr/local/bin
+export INC_PATH	:= /usr/local/include
+export LIB_PATH	:= /usr/local/lib
+else
+export BIN_PATH	:= /opt/magaox/bin
+export INC_PATH	:= /opt/magaox/include
+export LIB_PATH	:= /opt/magaox/lib
+endif
 
 all:
 	$(MAKE) -f makefile.server all

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The client receives the images and updates an ImageStreamIO buffer on a remote c
 ## Building
 
 Requirements:
- - c++14 compiler (tested on gcc)
+ - c++23 compiler (tested on gcc 13.x)
  - ImageStreamIO
  - ZeroMQ
 
@@ -131,6 +131,8 @@ options:
     -p    specify the port number of the server [default = 5556].
     -u    specify the loop sleep time in usecs [default = 1000].
     -f    specify the F.P.S. target [default = 10.0].
+    -x    turn on compression for INT16 and UINT16 types [default is off].
+    -a    If no shm-names are listed, export all from MILK_SHM_DIR.
 ```
 
 ### milkzmqClient

--- a/makefile.client
+++ b/makefile.client
@@ -1,26 +1,16 @@
 ######################################################
-## makefile for milkzmqClient                         ##
-##                                                  ## 
-## Edit BIN_PATH to specify installation directory. ##
+## Makefile for milkzmqClient.                      ##
 ######################################################
 
-BIN_PATH?=$(HOME)/bin
-INC_PATH?=$(HOME)/include
-
-######################################################
-
-
-TARGET=milkzmqClient
-HEADER=milkzmqClient.hpp
-
-
-OPTIMIZE ?= -O3 -ffast-math
-
-INCLUDES += -I/usr/local/milk/include
-
-CXXFLAGS += -std=c++14 $(OPTIMIZE) $(INCLUDES)
-
-LDLIBS += -lzmq -L /usr/local/milk/lib -lImageStreamIO -lxrif -lpthread
+TARGET		 = milkzmqClient
+HEADER		 = milkzmqClient.hpp
+BIN_PATH	?= $(HOME)/bin
+INC_PATH	?= $(HOME)/include
+LIB_PATH	?= $(HOME)/lib
+OPTIMIZE 	?= -O3 -ffast-math
+INCLUDES 	+= -I$(INC_PATH)
+CXXFLAGS	+= -std=c++23 $(OPTIMIZE) $(INCLUDES)
+LDLIBS 		+= -lzmq -L$(LIB_PATH) -lImageStreamIO -lxrif -lpthread
 
 all: $(TARGET) 
 

--- a/makefile.server
+++ b/makefile.server
@@ -1,28 +1,18 @@
 ######################################################
-## makefile for milkzmqServer                         ##
-##                                                  ## 
-## Edit BIN_PATH to specify installation directory. ##
+## Makefile for milkzmqServer.                      ##
 ######################################################
 
-BIN_PATH?=$(HOME)/bin
-INC_PATH?=$(HOME)/include
+TARGET		 = milkzmqServer
+HEADER		 = milkzmqServer.hpp
+BIN_PATH	?= $(HOME)/bin
+INC_PATH	?= $(HOME)/include
+LIB_PATH	?= $(HOME)/lib
+OPTIMIZE 	?= -O3 -ffast-math
+INCLUDES 	+= -I$(INC_PATH) -Itest
+CXXFLAGS 	+= -std=c++23 $(OPTIMIZE) $(INCLUDES)
+LDLIBS 		+= -lzmq -L$(LIB_PATH) -lImageStreamIO -lxrif -lpthread
 
-######################################################
-
-
-TARGET=milkzmqServer
-HEADER=milkzmqServer.hpp
-
-
-OPTIMIZE ?= -O3 -ffast-math
-
-INCLUDES += -I/usr/local/milk/include
-
-CXXFLAGS += -std=c++14 $(OPTIMIZE) $(INCLUDES)
-
-LDLIBS += -lzmq -L /usr/local/milk/lib -lImageStreamIO -lxrif -lpthread
-
-all: $(TARGET) 
+all: $(TARGET) ims3_rand_send
 
 $(TARGET): $(HEADER) milkzmqUtils.hpp
 
@@ -35,6 +25,9 @@ install: all
 
 .PHONY: clean
 clean:
-	rm -f $(TARGET)
-	rm -f *.o 
+	rm -f $(TARGET) ims3_rand_send
+	rm -f *.o test/*.o
 	rm -f *~
+
+ims3_rand_send: test/ims3.o test/ims3_rand_send.o
+	$(CXX) -o $@ $^ $(LDLIBS)

--- a/milkzmqServer.hpp
+++ b/milkzmqServer.hpp
@@ -30,10 +30,14 @@
 
 #include <signal.h>
 #include <fcntl.h>  // for open
+#include <sys/inotify.h>
 #include <sys/stat.h> //for stat (inodes)
 
-#include <unordered_map>
+#include <boost/algorithm/string/predicate.hpp>
+#include <filesystem>
+#include <list>
 #include <mutex>
+#include <unordered_map>
 
 #define ZMQ_BUILD_DRAFT_API
 #define ZMQ_CPP11
@@ -580,7 +584,7 @@ void milkzmqServer::serverThreadExec()
       {
          //Wait for next request from a client
          #if(CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1))
-         m_server->recv (request);
+         static_cast<void>(m_server->recv (request)); // method has nodiscard attribute.
          #else
          m_server->recv(&request);
          #endif

--- a/milkzmqServer.service
+++ b/milkzmqServer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=milk-zmq-server
+After=network.target syslog.target
+
+[Service]
+ExecStart=/opt/magaox/bin/milkzmqServer -a
+User=root
+RestartSec=5
+Restart=always
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/test/ims3.cc
+++ b/test/ims3.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024 The Arizona Board of Regents on behalf of the
+ * University of Arizona. All rights reserved.
+ *
+ * This file is part of CHAI.
+ *
+ * CHAI is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * CHAI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with CHAI. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ims3.h"
+
+std::unordered_map<std::size_t, std::size_t> chai::masala::ImStream3::typeToSizeMap = {
+    {_DATATYPE_UINT8, SIZEOF_DATATYPE_UINT8},   {_DATATYPE_UINT16, SIZEOF_DATATYPE_UINT16}, {_DATATYPE_UINT32, SIZEOF_DATATYPE_UINT32},
+    {_DATATYPE_UINT64, SIZEOF_DATATYPE_UINT64}, {_DATATYPE_INT8, SIZEOF_DATATYPE_INT8},     {_DATATYPE_INT16, SIZEOF_DATATYPE_INT16},
+    {_DATATYPE_INT32, SIZEOF_DATATYPE_INT32},   {_DATATYPE_INT64, SIZEOF_DATATYPE_INT64},   {_DATATYPE_FLOAT, SIZEOF_DATATYPE_FLOAT},
+    {_DATATYPE_DOUBLE, SIZEOF_DATATYPE_DOUBLE}};
+
+chai::masala::ImStream3::ImStream3(std::string name, std::size_t width, std::size_t height, std::size_t datatype)
+    : init(false), name(name), im(nullptr), width(width), height(height), datatype(datatype) {
+  std::string path = "/milk/shm/" + name + ".im.shm";
+  if (std::filesystem::exists(path)) {
+    open();  // If the image stream already exists, open it.
+  } else {
+    if (0 == width || height == 0 || datatype == _DATATYPE_UNINITIALIZED) {
+      throw new std::runtime_error("ims3::ctor insufficient parameters");
+    } else {
+      create();  // If it doesn't and we have the parameters, make it.
+    }
+  }
+  semNum = ImageStreamIO_getsemwaitindex(im, semNum);  // Get a semaphore number.
+  init = true;                                         // If we make it here, we're initialized.
+}
+
+chai::masala::ImStream3::~ImStream3() {
+  if (im != nullptr) {
+    ImageStreamIO_closeIm(im);
+    delete im;
+    im = nullptr;
+  }
+}
+
+void chai::masala::ImStream3::open() {
+  im = new IMAGE();  // Open the image stream.
+  if (im == nullptr) throw new std::runtime_error("ims3::open new");
+  if (0 != ImageStreamIO_openIm(im, name.c_str())) throw new std::runtime_error("ims3::open openIm");
+
+  datatype = im->md->datatype;  // Get metadata.
+  width = im->md->size[0];
+  height = im->md->naxis == 1 ? 1 : im->md->size[1];
+  sizeBytes = width * height * typeToSizeMap[datatype];
+}
+
+void chai::masala::ImStream3::create() {
+  im = new IMAGE();                                                     // Make room for an image stream object.
+  if (im == nullptr) throw new std::runtime_error("ims3::create new");  // Check that everything's okay so far.
+  std::size_t naxis = 2;                                                // We're going to assume two dimensions.
+  uint32_t imsize[naxis] = {(uint32_t)width, (uint32_t)height};         // Still assuming two dims.
+  sizeBytes = width * height * typeToSizeMap[datatype];                 // Record the size in bytes.
+  if (0 != ImageStreamIO_createIm_gpu(im, name.c_str(), naxis, imsize,  // Create the stream.
+                                      datatype, -1, 1, 10, 0,           //
+                                      IMG_SENT | ZAXIS_UNDEF, 1)) {     //
+    throw new std::runtime_error("ims3::create createIm");              // Tell everyone if something goes wrong.
+  }
+}
+
+int chai::masala::ImStream3::read(void *__restrict__ p, struct timespec *__restrict__ atime) {
+  if (!init) return ENOENT;                      // If we aren't initialzied, don't even try.
+  if (p == nullptr) return EINVAL;               // Try not to segfault.
+  uint64_t count = im->md->cnt0;                 // Get the count before we wait.
+  ImageStreamIO_semwait(im, semNum);             // Wait until someone writes to the stream.
+  memcpy(p, im->array.raw, sizeBytes);           // Copy to the buffer.
+  if (atime != nullptr) *atime = im->md->atime;  // If requested, copy the time.
+  return im->md->cnt0 - count;                   // Return the difference to see if we missed.
+}
+
+int chai::masala::ImStream3::read_spin(void *__restrict__ p, struct timespec *__restrict__ atime) {
+  if (!init) return ENOENT;                      // If we aren't initialzied, don't even try.
+  if (p == nullptr) return EINVAL;               // Try not to segfault.
+  uint64_t count = im->md->cnt0;                 // Get the current count.
+  while (count == im->md->cnt0) sched_yield();   // Wait until it changes.
+  memcpy(p, im->array.raw, sizeBytes);           // Copy to the buffer.
+  if (atime != nullptr) *atime = im->md->atime;  // If requested, copy the time.
+  return 0;                                      // Success!
+}
+
+int chai::masala::ImStream3::read_non_blocking(void *__restrict__ p, struct timespec *__restrict__ atime) {
+  if (!init) return ENOENT;                      // If we aren't initialized, don't even try.
+  if (p == nullptr) return EINVAL;               // Try not to segfault.
+  std::memcpy(p, im->array.raw, sizeBytes);      // Copy to the buffer.
+  if (atime != nullptr) *atime = im->md->atime;  // If requested, copy the time.
+  return 0;                                      // Success!
+}
+
+void chai::masala::ImStream3::cancel_blocking_read() { ImageStreamIO_sempost(im, semNum); }
+
+int chai::masala::ImStream3::send(void *__restrict__ p, struct timespec atime) {
+  if (!init) return ENOENT;                           // If we aren't initialized, don't even try.
+  if (p == nullptr) return EINVAL;                    // Try not to segfault.
+  im->md->write = MD_WRITE_START;                     // Signal the start of the write.
+  std::memcpy(im->array.raw, p, sizeBytes);           // Do the copy.
+  im->md->write = MD_WRITE_DONE;                      // Signal that we're done.
+  im->md->cnt0++;                                     // Update the image counter.
+  clock_gettime(CLOCK_REALTIME, &im->md->writetime);  // Set the write time.
+  im->md->atime = atime;                              // Set the acquisition time.
+  ImageStreamIO_sempost(im, ALL_SEMAPHORES);          // Let everyone know.
+  return 0;                                           // Success!
+}

--- a/test/ims3.h
+++ b/test/ims3.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 The Arizona Board of Regents on behalf of the
+ * University of Arizona. All rights reserved.
+ *
+ * This file is part of CHAI.
+ *
+ * CHAI is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * CHAI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with CHAI. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <ImageStreamIO/ImageStreamIO.h>
+
+#include <cstring>
+#include <filesystem>
+#include <unordered_map>
+
+namespace chai {
+namespace masala {
+
+class ImStream3 {
+ private:
+  int semNum;
+  bool init;
+  std::string name;
+  IMAGE *im;
+  std::size_t width, height, datatype, sizeBytes;
+
+  static std::unordered_map<std::size_t, std::size_t> typeToSizeMap;
+
+  //! Open an existing image stream.
+  void open();
+
+  //! Create an image stream with the parameters we have.
+  void create();
+
+ public:
+  //! Constructor.
+  ImStream3(std::string name, std::size_t width = 0, std::size_t height = 0, std::size_t datatype = _DATATYPE_UNINITIALIZED);
+
+  //! Destructor.
+  ~ImStream3();
+
+  //! Simple blocking read on an image stream.
+  int read(void *p, struct timespec *atime);
+
+  //! A spinning read on an image stream.
+  int read_spin(void *p, struct timespec *atime);
+
+  //! Non-blocking read, i.e. read whatever is in the buffer.
+  int read_non_blocking(void *p, struct timespec *atime);
+
+  //! Cancel a blocking read. Be careful because you might wake up others.
+  void cancel_blocking_read();
+
+  //! Write into an image stream.
+  int send(void *p, struct timespec atime = {0, 0});
+};
+
+}  // namespace masala
+}  // namespace chai
+
+#ifndef ALL_SEMAPHORES
+#define ALL_SEMAPHORES (-1)
+#endif
+
+#ifndef MD_WRITE_START
+#define MD_WRITE_START (1)
+#endif
+
+#ifndef MD_WRITE_DONE
+#define MD_WRITE_DONE (0)
+#endif

--- a/test/ims3_rand_send.cc
+++ b/test/ims3_rand_send.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 The Arizona Board of Regents on behalf of the
+ * University of Arizona. All rights reserved.
+ *
+ * This file is part of CHAI.
+ *
+ * CHAI is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * CHAI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with CHAI. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <array>
+#include <chrono>
+#include <iostream>
+#include <random>
+#include <string>
+#include <thread>
+
+#include "ims3.h"
+
+#define DIM 32
+
+using namespace std::chrono_literals;
+
+static std::string rand_str(int len) {
+  static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, sizeof(alphabet) - 2);
+  std::string retval;
+  for (int i = 0; i < len; i++) {
+    retval += alphabet[dis(gen)];
+  }
+  return retval;
+}
+
+static void fill(std::array<float, DIM * DIM>& data) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<float> dis;
+  for (int i = 0; i < data.size(); i++) {
+    data[i] = dis(gen);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  // Open a randomly named image stream.
+  auto name = rand_str(16);
+  auto is = new chai::masala::ImStream3(name, DIM, DIM, _DATATYPE_FLOAT);
+  std::cout << std::format("New image stream is named {}.", name) << std::endl;
+
+  // Make some data and send it at one hz.
+  std::array<float, DIM * DIM> arr;
+  while (true) {
+    fill(arr);
+    is->send(arr.data());
+    std::this_thread::sleep_for(1s);
+  }
+  return 0;
+}


### PR DESCRIPTION
Three commits are packaged here.

In the first, an option ("-a") is added to the milkzmqServer that spawns a thread for all of the image streams in MILK_SHM_DIR; it also spawns a thread that uses inotify to wait for new image streams to be created and then spawns threads for the new image streams. This changes necessitates moving to a newer C++ variant for std::format and std::filesystem. The code was built and tested with GCC 12 and 13 with the standard set to C++23.

In the second, changes are made to Makefiles and other supporting files. By default, files are installed in /usr/local. CHAI puts these files in /opt/magaox. The changes support both in that if /opt/magaox exists, installed files go there, otherwise /usr/local/. A CHAI-style clang-format file is included so that the code in `test` could be formatted properly as it was written. I tried to not reflexively apply styles while editing other files to isolate changes.

In the third, the readme is updated to add the -x and -a option text.