### PR TITLE
Fix mzmq frame and thread lifetimes

### DIFF
--- a/milkzmqClient.hpp
+++ b/milkzmqClient.hpp
@@ -67,7 +67,6 @@ class milkzmqClient
     {
         std::thread *m_thread{
             nullptr };            ///< Thread for receiving image slice updates.  A pointer to allow copying, but must be deleted in d'tor of parent.
-        milkzmqClient *m_mzc;     ///< a pointer to a milkzmqClient instance (normally this)
         std::string m_imageName;  ///< the name of the image to subscribe from this thread
         std::string m_localImageName;  ///< optional local name of this image stream.  Ignored if "".
 
@@ -169,7 +168,10 @@ class milkzmqClient
 
    private:
     /// Thread starter, called by imageThreadStart on thread construction.  Calls imageThreadExec.
-    static void internal_imageThreadStart( s_imageThread *mit /**< [in] a pointer to an s_imageThread structure */ );
+    static void internal_imageThreadStart( milkzmqClient *mzc,        /**< [in] the client instance executing the thread */
+                                           std::string imageName,     /**< [in] the remote image stream to subscribe to */
+                                           std::string localImageName /**< [in] the local image stream name */
+    );
 
    public:
     /// Start the image thread.
@@ -283,7 +285,6 @@ inline int milkzmqClient::shMemImName( const std::string &name, const std::strin
 {
     s_imageThread nt;
 
-    nt.m_mzc = this;
     nt.m_imageName = name;
     nt.m_localImageName = localName;
 
@@ -308,16 +309,28 @@ inline std::string milkzmqClient::localShMemImName( size_t imno )
     return m_imageThreads[imno].m_localImageName;
 }
 
-inline void milkzmqClient::internal_imageThreadStart( s_imageThread *mit )
+inline void milkzmqClient::internal_imageThreadStart( milkzmqClient *mzc, std::string imageName, std::string localImageName )
 {
-    mit->m_mzc->imageThreadExec( mit->m_imageName, mit->m_localImageName );
+    try
+    {
+        mzc->imageThreadExec( imageName, localImageName );
+    }
+    catch( const std::exception &e )
+    {
+        mzc->reportError( std::string( "exception in image thread execution: " ) + e.what(), __FILE__, __LINE__ );
+    }
+    catch( ... )
+    {
+        mzc->reportError( "unknown exception in image thread execution", __FILE__, __LINE__ );
+    }
 }
 
 inline int milkzmqClient::imageThreadStart( size_t thno )
 {
     try
     {
-        *m_imageThreads[thno].m_thread = std::thread( internal_imageThreadStart, &m_imageThreads[thno] );
+        *m_imageThreads[thno].m_thread =
+            std::thread( internal_imageThreadStart, this, m_imageThreads[thno].m_imageName, m_imageThreads[thno].m_localImageName );
     }
     catch( const std::exception &e )
     {
@@ -368,7 +381,7 @@ inline void milkzmqClient::imageThreadExec( const std::string &imageName, const 
      */
 
     IMAGE image;
-    bool opened = false;
+    bool created = false;
 
     uint32_t imsize[3];
 
@@ -494,14 +507,20 @@ inline void milkzmqClient::imageThreadExec( const std::string &imageName, const 
                 imsize[1] = new_ny;
                 imsize[2] = 0;
 
-                if( opened )
+                if( created )
                 {
                     ImageStreamIO_destroyIm( &image );
+                    created = false;
                 }
 
-                ImageStreamIO_createIm( &image, shMemImName.c_str(), 2, imsize, new_atype, 1, 0, 0 );
+                if( ImageStreamIO_createIm( &image, shMemImName.c_str(), 2, imsize, new_atype, 1, 0, 0 ) != 0 )
+                {
+                    reportWarning( "Could not create local ImageStream " + shMemImName + ", reconnecting." );
+                    reconnect = true;
+                    continue;
+                }
 
-                opened = true;
+                created = true;
 
                 xe = xrif_set_size( xrif, new_nx, new_ny, 1, 1, new_atype );
                 xrif_set_difference_method( xrif, *( (int16_t *)( raw_image + xrifDifferenceOffset ) ) );
@@ -517,6 +536,13 @@ inline void milkzmqClient::imageThreadExec( const std::string &imageName, const 
 
             // This is not a rolling buffer.
             curr_image = 0;
+
+            if( !created )
+            {
+                reportWarning( "No local ImageStream is available for " + imageName + ", reconnecting." );
+                reconnect = true;
+                continue;
+            }
 
             size_t type_size = ImageStreamIO_typesize( image.md[0].datatype );
 
@@ -576,9 +602,11 @@ inline void milkzmqClient::imageThreadExec( const std::string &imageName, const 
 
         // To trigger a full reconnect:
 
-        if( opened )
-            ImageStreamIO_closeIm( &image );
-        opened = false;
+        if( created )
+        {
+            ImageStreamIO_destroyIm( &image );
+            created = false;
+        }
 
         atype = 0;
         nx = 0;
@@ -596,8 +624,8 @@ inline void milkzmqClient::imageThreadExec( const std::string &imageName, const 
 
     }  // outer loop (checking stale connections)
 
-    if( opened )
-        ImageStreamIO_closeIm( &image );
+    if( created )
+        ImageStreamIO_destroyIm( &image );
     xrif_delete( xrif );
 
 }  // milkzmqClient::imageThreadExec()

--- a/milkzmqServer.hpp
+++ b/milkzmqServer.hpp
@@ -700,6 +700,7 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
         int printed = 0;
 
         ino_t inode{ 0 };
+        off_t fileSize{ 0 };
 
         while( !opened && !m_timeToDie.load( std::memory_order_relaxed ) && restartEpoch() == localRestartEpoch )
         {
@@ -743,6 +744,7 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
                     else
                     {
                         inode = statbuff.st_ino;
+                        fileSize = statbuff.st_size;
                     }
                 }
             }
@@ -953,6 +955,12 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
                 if( statbuff.st_ino != inode )
                 {
                     std::cerr << "inode changed " << statbuff.st_ino << " " << inode << "\n";
+                    break;
+                }
+
+                if( statbuff.st_size != fileSize )
+                {
+                    std::cerr << "file size changed " << statbuff.st_size << " " << fileSize << "\n";
                     break;
                 }
 

--- a/milkzmqServer.hpp
+++ b/milkzmqServer.hpp
@@ -35,10 +35,12 @@
 
 #include <atomic>
 #include <boost/algorithm/string/predicate.hpp>
+#include <cstring>
 #include <filesystem>
 #include <list>
 #include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #define ZMQ_BUILD_DRAFT_API
 #define ZMQ_CPP11
@@ -103,7 +105,6 @@ class milkzmqServer
     {
         std::thread *m_thread{
             nullptr };            ///< Thread for publishing image slice updates.  A pointer to allow copying, but must be deleted in d'tor of parent.
-        milkzmqServer *m_mzs;     ///< a pointer to a milkzmqServer instance (normally this)
         std::string m_imageName;  ///< the name of the image to serve from this thread
 
         /// C'tor to create the thread object
@@ -281,7 +282,9 @@ class milkzmqServer
 
    private:
     /// Image thread starter, called by imageThreadStart on thread construction.  Calls imageThreadExec.
-    static void internal_imageThreadStart( s_imageThread *mit /**< [in] a pointer to an s_imageThread structure */ );
+    static void internal_imageThreadStart( milkzmqServer *mzs,   /**< [in] the server instance executing the thread */
+                                           std::string imageName /**< [in] the image stream to monitor and publish */
+    );
 
    public:
     /// Start the image thread.
@@ -409,7 +412,6 @@ inline int milkzmqServer::shMemImName( const std::string &name )
 {
     s_imageThread nt;
 
-    nt.m_mzs = this;
     nt.m_imageName = name;
 
     m_imageThreads.push_back( nt );
@@ -509,7 +511,18 @@ inline int milkzmqServer::xrifCompressMethod()
 
 inline void milkzmqServer::internal_serverThreadStart( milkzmqServer *mzs )
 {
-    mzs->serverThreadExec();
+    try
+    {
+        mzs->serverThreadExec();
+    }
+    catch( const std::exception &e )
+    {
+        mzs->reportError( std::string( "exception in server thread execution: " ) + e.what(), __FILE__, __LINE__ );
+    }
+    catch( ... )
+    {
+        mzs->reportError( "unknown exception in server thread execution", __FILE__, __LINE__ );
+    }
 }
 
 inline int milkzmqServer::serverThreadStart()
@@ -604,16 +617,27 @@ inline int milkzmqServer::serverThreadKill()
     return 0;
 }
 
-inline void milkzmqServer::internal_imageThreadStart( s_imageThread *mit )
+inline void milkzmqServer::internal_imageThreadStart( milkzmqServer *mzs, std::string imageName )
 {
-    mit->m_mzs->imageThreadExec( mit->m_imageName );
+    try
+    {
+        mzs->imageThreadExec( imageName );
+    }
+    catch( const std::exception &e )
+    {
+        mzs->reportError( std::string( "exception in image thread execution: " ) + e.what(), __FILE__, __LINE__ );
+    }
+    catch( ... )
+    {
+        mzs->reportError( "unknown exception in image thread execution", __FILE__, __LINE__ );
+    }
 }
 
 inline int milkzmqServer::imageThreadStart( size_t thno )
 {
     try
     {
-        *m_imageThreads[thno].m_thread = std::thread( internal_imageThreadStart, &m_imageThreads[thno] );
+        *m_imageThreads[thno].m_thread = std::thread( internal_imageThreadStart, this, m_imageThreads[thno].m_imageName );
     }
     catch( const std::exception &e )
     {
@@ -650,7 +674,7 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
 
     bool opened = false;
 
-    uint8_t *msg = nullptr;
+    std::vector<uint8_t> msgBuffer;
 
     while( m_server == nullptr )
     {
@@ -763,22 +787,12 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
 
         xe = xrif_configure( xrif, xrifDifferenceMethod, xrifReorderMethod, xrifCompressMethod );
 
-        //---- Allocate the message
-        if( msg != nullptr )
-        {
-            // problem: if msg is not nullptr, then it means that it was allocated and
-            // most likely handed over to zmq for sending.  We can't afford to free it
-            // until zmq actually decides it's done with it.
-            // for now: we sleep.
-            sleep( 2 );
-            free( msg );
-        }
         size_t msgSz = headerSize + xrif_min_raw_size( xrif );  // This is maximum message size.
-        msg = (uint8_t *)malloc( msgSz );
+        msgBuffer.resize( msgSz );
 
         //---- Allocate XRIF
         xe = xrif_set_size( xrif, last_snx, last_sny, 1, 1, last_atype );
-        xe = xrif_set_raw( xrif, msg + headerSize, xrif_min_raw_size( xrif ) );
+        xe = xrif_set_raw( xrif, msgBuffer.data() + headerSize, xrif_min_raw_size( xrif ) );
         xe = xrif_allocate_reordered( xrif );
 
         double lastCheck = get_curr_time();
@@ -862,6 +876,7 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
                 // std::cerr << imageName << " XRIF: " << xrif->compression_ratio*100. << "%\n";
 
                 //----Now construct header
+                uint8_t *msg = msgBuffer.data();
                 memset( msg, 0, headerSize );
                 snprintf( (char *)msg, nameSize, "%s", imageName.c_str() );
                 *( (uint8_t *)( msg + typeOffset ) ) = atype;
@@ -885,7 +900,8 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
                 {
                     for( size_t rid = 0; rid < rids.size(); ++rid )
                     {
-                        zmq::message_t frame( msg, headerSize + xrif->compressed_size, nullptr, nullptr );  // this version will not copy the data.
+                        zmq::message_t frame( headerSize + xrif->compressed_size );
+                        memcpy( frame.data(), msgBuffer.data(), frame.size() );
                         frame.set_routing_id( rids[rid] );
                         try
                         {
@@ -982,11 +998,10 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
     }
     if( rids.size() > 0 )
     {
-        char zero = '\0';
-
         for( size_t rid = 0; rid < rids.size(); ++rid )
         {
-            zmq::message_t frame( &zero, sizeof( char ), nullptr, nullptr );
+            zmq::message_t frame( sizeof( char ) );
+            *( static_cast<char *>( frame.data() ) ) = '\0';
             frame.set_routing_id( rids[rid] );
             try
             {
@@ -1011,8 +1026,6 @@ inline void milkzmqServer::imageThreadExec( const std::string &imageName )
     // One more check
     if( opened )
         ImageStreamIO_closeIm( &image );
-    if( msg )
-        free( msg );
     if( xrif != nullptr )
         xrif_delete( xrif );
 


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "The mzmqServer is prone to segfaults when streams are resized. It seems most common when the source of the streams is an mzmqClient. You can find the source for milkzmq at ../milkzmq/, changes to that are in scope. mzmqClient has also shown some occasional instability but not as common/pronounced as in mzmqServer. Please analyze these apps for possible causes of segfaults and other crashes."

## Summary
Fix `milkzmqServer` and `milkzmqClient` lifetime hazards that could lead to crashes during resize/reconnect events.

## Changes
- Make server sends use ZeroMQ-owned frame memory instead of borrowed reusable buffers.
- Pass copied stream names into worker threads so thread startup no longer depends on `m_imageThreads` element addresses.
- Catch top-level server/client worker thread exceptions and report them instead of terminating abruptly.
- Make client local shmim recreation/cleanup consistent across resize and reconnect paths.

## Why
The main crash risk was a send-buffer lifetime bug in `milkzmqServer`, with additional instability from thread-start lifetime issues and inconsistent client-side shmim cleanup.

## Testing
- `clang-format` run on touched files.
- Standalone `milkzmqServer` and `milkzmqClient` builds succeeded locally.
- Initial flight-hardware resize testing looks good.
